### PR TITLE
Add security hook and component

### DIFF
--- a/src/components/security/Security.hooks.ts
+++ b/src/components/security/Security.hooks.ts
@@ -55,6 +55,11 @@ export const useSecurity = function <TValues, TErrors extends Errors = Errors>({
     })();
   }, [valid, values]);
 
+  if (useErrorBoundary && !valid) {
+    const [message] = Object.values(errors);
+    throw new Error(message as string);
+  }
+
   return {
     values,
     valid,

--- a/src/components/security/Security.hooks.ts
+++ b/src/components/security/Security.hooks.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export type Errors = Record<string, string>;
+
+export const attempt = <T = any>(functionOrNot: ((...args: any) => T) | T, ...args: any) => {
+  try {
+    return typeof functionOrNot === 'function'
+      ? (functionOrNot as (...args: any) => T)(...args)
+      : functionOrNot;
+  } catch (e) {
+    return functionOrNot;
+  }
+};
+
+export type Validate<TValues = unknown, TErrors extends Errors = Errors> = (
+  values: TValues
+) => TErrors;
+
+export type SecurityOptions<TValues, TErrors extends Errors = Errors> = {
+  values: TValues;
+  validate: Validate<TValues, TErrors>;
+  useErrorBoundary: boolean;
+  onSuccess?: (values: TValues) => void;
+  onError?: (errors: TErrors) => void;
+};
+
+export type SecurityResult<TValues> = {
+  values: TValues;
+  valid: boolean;
+  errors?: Errors;
+  reset: () => void;
+};
+export const useSecurity = function <TValues, TErrors extends Errors = Errors>({
+  values,
+  validate,
+  useErrorBoundary = true,
+  onSuccess,
+  onError,
+}: SecurityOptions<TValues, TErrors>) {
+  const [errors, setErrors] = useState({});
+  const valid = useMemo(() => !!errors && Object.keys(errors).length === 0, [errors]);
+  const reset = useCallback(() => {
+    setErrors({});
+  }, []);
+
+  useEffect(() => {
+    if (!valid) return;
+    (async () => {
+      const errors = await validate(values);
+      const valid = Object.keys(errors).length === 0;
+      setErrors(errors);
+
+      if (valid) onSuccess?.(values);
+      else onError?.(errors);
+    })();
+  }, [valid, values]);
+
+  return {
+    values,
+    valid,
+    errors,
+    reset,
+  };
+};

--- a/src/components/security/Security.tsx
+++ b/src/components/security/Security.tsx
@@ -1,0 +1,21 @@
+import { ReactNode, useState } from 'react';
+import {
+  attempt,
+  SecurityOptions,
+  useSecurity,
+  Errors,
+  SecurityResult,
+} from '@/components/security/Security.hooks';
+
+export type SecurityProps<TValues = unknown, TErrors extends Errors = Errors> = SecurityOptions<
+  TValues,
+  TErrors
+> & {
+  children?: ReactNode | ((arg: SecurityResult<TValues>) => ReactNode);
+};
+export const Security = <TValues, TErrors extends Errors>({
+  children,
+  ...options
+}: SecurityProps<TValues, TErrors>) => {
+  return <>{attempt(children, useSecurity<TValues, TErrors>(options))}</>;
+};

--- a/src/components/security/index.ts
+++ b/src/components/security/index.ts
@@ -1,0 +1,2 @@
+export * from './Security';
+export * from './Security.hooks';


### PR DESCRIPTION
### Summary

페이지 진입 시 보안 처리를 위한 Security 컴포넌트와 훅을 추가합니다.
- `attempt()` : functionOrNot을 인자로 받고, 함수라면 실행 / 함수가 아니라면 그대로 리턴합니다.
- `useSecurity()` : values, validate 등을 인자로 받습니다. values를 이용해 validate 한 후 에러 케이스일 경우 onError에 맞는 동작을 취합니다.

아직 테스트는 못해봤습니다.

### Screenshots
생략